### PR TITLE
Add Ruby Chespirito

### DIFF
--- a/Ruby/Chespirito/Dockerfile
+++ b/Ruby/Chespirito/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:3.3.0-preview1 AS base
+ENV RUBY_YJIT_ENABLE=1
+WORKDIR /app
+
+FROM base AS prod
+COPY Gemfile .
+COPY Gemfile.lock .
+RUN bundle install 
+COPY . .
+EXPOSE 4000
+CMD ["rackup"]

--- a/Ruby/Chespirito/Dockerfile
+++ b/Ruby/Chespirito/Dockerfile
@@ -3,9 +3,12 @@ ENV RUBY_YJIT_ENABLE=1
 WORKDIR /app
 
 FROM base AS prod
+# Gems
 COPY Gemfile .
 COPY Gemfile.lock .
 RUN bundle install 
-COPY . .
+# App
+COPY config.ru .
+# Expose and run
 EXPOSE 4000
 CMD ["rackup"]

--- a/Ruby/Chespirito/Gemfile
+++ b/Ruby/Chespirito/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'rack'
+gem 'rackup'
+gem 'chespirito', require: 'chespirito'
+gem 'puma', require: 'rack/handler/puma'

--- a/Ruby/Chespirito/Gemfile.lock
+++ b/Ruby/Chespirito/Gemfile.lock
@@ -1,0 +1,28 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    adelnor (0.0.6)
+      rack
+    chespirito (0.0.3)
+      adelnor
+      rack
+    nio4r (2.5.9)
+    puma (6.3.1)
+      nio4r (~> 2.0)
+    rack (3.0.8)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    webrick (1.8.1)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  chespirito
+  puma
+  rack
+  rackup
+
+BUNDLED WITH
+   2.4.10

--- a/Ruby/Chespirito/README.md
+++ b/Ruby/Chespirito/README.md
@@ -1,0 +1,40 @@
+## Ruby - Chespirito
+
+The Ruby fibaas®️  version using [Chespirito](https://github.com/leandronsp/chespirito).
+
+## Stack
+
+* Ruby 3.3.0-preview0 +YJIT
+* Puma
+* Chespirito
+
+## Requirements
+
+Docker
+
+## Running
+```bash
+$ cd Ruby/Chespirito
+$ docker compose up
+
+# or 
+
+$ docker build -t fibaas-ruby-chespirito --target prod
+$ docker run -p 4000:4000 fibaas-ruby-chespirito
+```
+
+## Stressing
+
+Puma (Threads: 0.5 | Forks: 0)
+```bash
+$ wrk -c 64 -d 30s http://localhost:4000/10
+
+Running 30s test @ http://localhost:4000/10 
+  2 threads and 64 connections          
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   653.97us  440.89us  48.48ms   98.48%
+    Req/Sec     3.07k   206.26     3.36k    89.33%
+  183318 requests in 30.01s, 11.54MB read                                             
+Requests/sec:   6109.51                                                               
+Transfer/sec:    393.78KB
+```

--- a/Ruby/Chespirito/README.md
+++ b/Ruby/Chespirito/README.md
@@ -25,7 +25,7 @@ $ docker run -p 4000:4000 fibaas-ruby-chespirito
 
 ## Stressing
 
-Puma (Threads: 0.5 | Forks: 0)
+Puma (Threads: 0:5 | Forks: 0)
 ```bash
 $ wrk -c 64 -d 30s http://localhost:4000/10
 
@@ -37,4 +37,18 @@ Running 30s test @ http://localhost:4000/10
   183318 requests in 30.01s, 11.54MB read                                             
 Requests/sec:   6109.51                                                               
 Transfer/sec:    393.78KB
+```
+
+Puma (Threads: 0:16 | Forks: 8)
+```bash
+$ wrk -c 64 -d 30s http://localhost:4000/10
+
+Running 30s test @ http://localhost:4000/10
+  2 threads and 64 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     3.34ms    4.12ms 130.04ms   93.19%
+    Req/Sec    11.69k     1.03k   14.03k    79.50%
+  698312 requests in 30.01s, 43.95MB read
+Requests/sec:  23267.97
+Transfer/sec:      1.46MB
 ```

--- a/Ruby/Chespirito/config.ru
+++ b/Ruby/Chespirito/config.ru
@@ -1,0 +1,26 @@
+require 'bundler'
+Bundler.require
+
+class FibonacciController < Chespirito::Controller
+  def fib(n)
+    case n
+      when 0 then 0
+      when 1 then 1
+      else fib(n - 1) + fib(n - 2)
+    end
+  end
+
+  def calculate
+    result = fib(request.params['number'].to_i)
+
+    response.body = result.to_s
+    response.status = 200
+    response.headers['Content-Type'] = 'text/plain'
+  end
+end
+
+FibonacciApp = Chespirito::App.configure do |app|
+  app.register_route('GET', '/:number', [FibonacciController, :calculate])
+end
+
+Rack::Handler::Puma.run(FibonacciApp, Port: 4000, Threads: ENV['THREAD_POOL'] || '0:5')

--- a/Ruby/Chespirito/docker-compose.yml
+++ b/Ruby/Chespirito/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.9'
+
+services:
+  ruby:
+    build:
+      context: .
+      target: base
+    volumes:
+      - .:/app
+      - rubygems:/usr/local/bundle
+    environment:
+      - THREAD_POOL=0:5
+        #- WEB_CONCURRENCY=4
+    working_dir: /app
+    command: rackup
+    ports: 
+      - 4000:4000
+volumes:
+  rubygems:

--- a/Ruby/Chespirito/docker-compose.yml
+++ b/Ruby/Chespirito/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       - .:/app
       - rubygems:/usr/local/bundle
     environment:
-      - THREAD_POOL=0:5
-        #- WEB_CONCURRENCY=4
+      - THREAD_POOL=0:16
+      - WEB_CONCURRENCY=8
     working_dir: /app
     command: rackup
     ports: 


### PR DESCRIPTION
Adding the [chespirito](https://github.com/leandronsp/chespirito) version for Ruby. 

## Tested environment

* Apple M1 Pro 16GB
* Docker (Orbstack)

## Test execution

1. Puma: Threads 0:5 | Forks: 0

```bash
$ wrk -c 64 -d 30s http://localhost:4000/10

Running 30s test @ http://localhost:4000/10 
  2 threads and 64 connections          
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   653.97us  440.89us  48.48ms   98.48%
    Req/Sec     3.07k   206.26     3.36k    89.33%
  183318 requests in 30.01s, 11.54MB read                                             
Requests/sec:   6109.51                                                               
Transfer/sec:    393.78KB
```

2. Puma: Threads: 0:16 | Forks: 8
```bash
$ wrk -c 64 -d 30s http://localhost:4000/10

Running 30s test @ http://localhost:4000/10
  2 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.34ms    4.12ms 130.04ms   93.19%
    Req/Sec    11.69k     1.03k   14.03k    79.50%
  698312 requests in 30.01s, 43.95MB read
Requests/sec:  23267.97
Transfer/sec:      1.46MB
```